### PR TITLE
Update Makefile - based on Gulzt idea of simplifying the grep syntax

### DIFF
--- a/apps-free/scope+gen/Makefile
+++ b/apps-free/scope+gen/Makefile
@@ -9,7 +9,7 @@ APP=$(notdir $(CURDIR:%/=%))
 # Versioning system
 BUILD_NUMBER ?= 0
 REVISION ?= devbuild
-VER:=$(shell cat info/info.json | grep version | sed -e 's/.*:\ *\"//' | sed -e 's/-.*//')
+VER:=$(shell grep version info/info.json | sed -E 's/[^:]*:[^"]*"([^-]*)-.*$/\1/')
 
 INSTALL_DIR ?= ../../build
 


### PR DESCRIPTION
Just for fun, retrieving the version number could have been done a lot more effective. Using 1 pipe instead of 3, and with saver syntax.